### PR TITLE
Refactor sorting mechanism and reuse on settings change

### DIFF
--- a/@angular-generic-table/core/components/generic-table.component.ts
+++ b/@angular-generic-table/core/components/generic-table.component.ts
@@ -970,17 +970,15 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>> 
     }
   };
 
-  ngOnInit() {
-
+  private restructureSorting = function () {
     /** Check and store sort order upon initialization.
      *  This is done by checking sort properties in the settings array of the table, if no sorting is defined
      *  we'll sort the data by the first visible and enabled column in the table(ascending). Please note that actually
      *  sorting have to be done server side when lazy loading data for obvious reasons.  */
-      // create sorting array
+    // create sorting array
     const sorting = [];
-    if (this._gtSettings){
-
-
+    if (this._gtSettings) {
+      
       // ...sort settings by sort order
       this._gtSettings.sort(this.getSortOrder);
 
@@ -1023,6 +1021,10 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>> 
     if (this.sortOrder.length === 0) {
       this.sortOrder = sorting;
     }
+  }
+
+  ngOnInit() {
+      this.restructureSorting();
   }
 
   /**
@@ -1082,6 +1084,7 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>> 
           this._gtSettings[i].columnOrder = this._gtSettings[i - 1] ? this._gtSettings[i - 1].columnOrder + 1 : 0;
         }
       }
+      this.restructureSorting();
     }
 
     // if lazy loading data and paging information is available...


### PR DESCRIPTION
The reason why the fields are empty because when the setting and fields changes, the sort does not get reset to look at the new column structure.
I pulled the existing code from ngOnInit into its own function and reuse the function in ngOnChanges when the settings changes.