### PR TITLE
Add events on columns settings changes

### DIFF
--- a/@angular-generic-table/column-settings/components/gt-column-settings.component.ts
+++ b/@angular-generic-table/column-settings/components/gt-column-settings.component.ts
@@ -1,6 +1,6 @@
 import {
     Component, Input, ViewChild, TemplateRef, ElementRef, Pipe, PipeTransform, OnInit,
-    ChangeDetectorRef, HostListener
+    ChangeDetectorRef, HostListener, Output, EventEmitter
 } from '@angular/core';
 import {GenericTableComponent, GtRow, GtConfigSetting } from '@angular-generic-table/core';
 import {DragulaService} from 'ng2-dragula';
@@ -85,6 +85,8 @@ export class GtColumnSettingsComponent implements OnInit{
     };
     @Input() gtTexts: GtColumnSettingsTexts = this.gtDefaultTexts;
 
+    @Output() public gtEvent: EventEmitter<any> = new EventEmitter<any>();
+
     public active = false;
     public offset: string;
     public heightAdjust: string;
@@ -157,6 +159,11 @@ export class GtColumnSettingsComponent implements OnInit{
 
         // redraw table
         this._genericTable.redraw();
+        this.gtEvent.emit({
+          name: 'gt-column-order-change',
+          column: column,
+          settings: this._genericTable.gtSettings
+        });
 
         // check and reset offset
         setTimeout(() => {
@@ -184,6 +191,10 @@ export class GtColumnSettingsComponent implements OnInit{
         this.changeDetectorRef.markForCheck();
 
         this._genericTable.redraw();
+        this.gtEvent.emit({
+          name: 'gt-column-order-change',
+          settings: this._genericTable.gtSettings
+        });
     }
 
     /**


### PR DESCRIPTION
Launch an event when user change visibility of column and its order.

It can be useful to save user preferences on each column settings updates.