### PR TITLE
Fix test attribute existance in gt render pipe

### DIFF
--- a/@angular-generic-table/core/pipes/gt-render.pipe.ts
+++ b/@angular-generic-table/core/pipes/gt-render.pipe.ts
@@ -109,7 +109,7 @@ export class GtRenderPipe<R extends GtRow> implements PipeTransform {
 
     for (let i = 0; i < fields.length; i++) {
       //console.log(!row[fields[i].objectKey]);
-      if (fields[i].value && typeof fields[i].value === 'function' && !row[fields[i].objectKey]) {
+      if (fields[i].value && typeof fields[i].value === 'function' && !row.hasOwnProperty(fields[i].objectKey)) {
         row[fields[i].objectKey] = loading ? '' : fields[i].value(row);
       }
     }


### PR DESCRIPTION
Hey,

I think i find a bug in the GtRenderPipe in a test.
When pipe test the value of attribute in the object, all values like `0`, `''`, `null` pass in the test and the original object is updated.
See example belong.

I have a collection of this type to pass to generic table :

```ts
class MyModel {
  public test: string = null;
}
```

And in my generic table configuration, i have :

```ts
const translateService = ...

this.settings = [
  {
    objectKey: 'test',
    sort: 'enable',
    columnOrder: 0
  }
];
this.fields = [
  {
    objectKey: 'test',
    value: (row: MyModel) => {
      if (!row.test) {
        // return default transformed value
      } else {
        // return transformed value contextualized by row.test
      }
    },
    render: (row: MyModel) => {
      // row.test will be equals to transformed default value
      if (!row.test) {
        return translateService.instant('label.all');
      } else {
        return translateService.instant('label.' + row.test);
      }
    }
  }
];
```

In this case (with `row.test  = null`), your code will set default transformed value from fields settings `value` in the original row object, so in the render my code pass in the `else`, not in the `if`.

In my fix, test test only the existance of the objectKey attribute in object, not the value which can be `0`, `''`, `null`, etc...