### PR TITLE
Allow latest node to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ script:
   - npm run build:new
   - npm run ci
 matrix:
+  fast_finish: true
   allow_failures:
     - node_js: "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ script:
   - npm run lint:ci
   - npm run build:new
   - npm run ci
+matrix:
+  allow_failures:
+    - node_js: "node"


### PR DESCRIPTION
In Travis, the latest LTS version of node (8.11.1) passes the build, but the latest version of node (10.0.0) doesn't, because `node-sass` doesn't support it yet. I think we can ignore this failure for now.

With this PR, Travis will still keep building on the latest node version, but won't call it a fail if that build fails.