### PR TITLE
Fix editorconfig settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,19 +3,17 @@ root = true
 
 [*]
 charset = utf-8
-indent_style = space
-indent_size = 2
+indent_style = tab
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{ts,json,scss,md},!{package{,-lock},.vscode/*}.json]
-indent_style = tab
+[*.{ts,scss,html}]
 max_line_length = 80
 
-# YAML files require space indentation
+# YAML files require space indentation.
 # (http://yaml.org/spec/1.2/spec.html#id2777534)
-[*.{yml,yaml}]
+[*.{y{,a}ml,json,html}]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
Json, yaml, and html files are indented with 2 spaces, the rest are indented with tabs.

The glob pattern wasn't expanding correctly when I [added the `.editorconfig` file](https://github.com/hjalmers/angular-generic-table/commit/a26af97516e0d08c7bd02dfb2f9defac894c9752); I forgot some braces.

Using 2 spaces makes it simpler in general, since a lot of these files are managed externally (`npm`, VSCode, etc.).

@hjalmers you can use this commit, or change it to suit your needs; just note that currently `.editorconfig` is broken. This doesn't conflict with `prettier` or `tslint`.