### PR TITLE
VSCode extension settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    "Angular.ng-template",
+    "EditorConfig.EditorConfig",
+    "PKief.material-icon-theme",
+    "eg2.tslint",
+    "esbenp.prettier-vscode",
+    "joelday.docthis",
+    "msjsdiag.debugger-for-chrome",
+    "natewallace.angular2-inline"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "docthis.includeTypes": false,
+  "docthis.includeMemberOfOnInterfaceMembers": false,
+  "docthis.includeMemberOfOnClassMembers": false
 }


### PR DESCRIPTION
Adds recommended Visual Studio Code extensions, and configures the Document This extension to be compatible with `ng-packagr`.