### PR TITLE
Use npm ci if supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ script:
   - npm run lint:ci
   - npm run build:all
   - npm run cypress:ci
+cache:
+  directories:
+    - "$HOME/.npm"
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ script:
   - npm run lint:ci
   - npm run build:all
   - npm run cypress:ci
+# unlink the library projects
+before_cache:
+  - npm remove -g @angular-generic-table/core
+  - npm remove -g @angular-generic-table/column-settings
 cache:
   directories:
     - "$HOME/.npm"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 node_js:
   - "lts/*"
   - "node"
-install:
-  - npm install
 before_script:
   - npm run tslint-check
 script:


### PR DESCRIPTION
Cache `~/.npm`, and unlink `@angular-generic-table/core` and `@angular-generic-table/column-settings` before caching.