### PR TITLE
Making a deep copy of data on adding/updating data

### DIFF
--- a/@angular-generic-table/column-settings/package-lock.json
+++ b/@angular-generic-table/column-settings/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@angular-generic-table/column-settings",
-	"version": "4.15.0",
+	"version": "4.16.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/@angular-generic-table/core/components/generic-table.component.ts
+++ b/@angular-generic-table/core/components/generic-table.component.ts
@@ -141,7 +141,9 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>>
 	}
 	@Input()
 	set gtData(initialData: Array<any>) {
-		const data = this._gtOptions.mutateData ? [...initialData] : this.cloneDeep(initialData);
+		const data = this._gtOptions.mutateData
+			? [...initialData]
+			: this.cloneDeep(initialData);
 		if (this.gtOptions.lazyLoad && this.gtInfo) {
 			this.gtMetaPipe.transform(
 				data,
@@ -1279,7 +1281,7 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>>
 
 	// TODO: move to helper functions
 	/** Create a deep copy of data */
-	private cloneDeep = function <T>(o: T): T {
+	private cloneDeep = function(o: any) {
 		return JSON.parse(JSON.stringify(o));
 	};
 

--- a/@angular-generic-table/core/components/generic-table.component.ts
+++ b/@angular-generic-table/core/components/generic-table.component.ts
@@ -140,7 +140,8 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>>
 		this.restructureSorting();
 	}
 	@Input()
-	set gtData(data: Array<any>) {
+	set gtData(initialData: Array<any>) {
+		const data = this._gtOptions.mutateData ? [...initialData] : this.cloneDeep(initialData);
 		if (this.gtOptions.lazyLoad && this.gtInfo) {
 			this.gtMetaPipe.transform(
 				data,
@@ -253,7 +254,8 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>>
 		rowExpandAllowMultiple: true,
 		numberOfRows: 10,
 		reportColumnWidth: false,
-		allowUnsorted: true
+		allowUnsorted: true,
+		mutateData: true
 	};
 	private _gtOptions: GtOptions = this.gtDefaultOptions;
 	public store: Array<any> = [];
@@ -1273,6 +1275,12 @@ export class GenericTableComponent<R extends GtRow, C extends GtExpandedRow<R>>
 			return 1;
 		}
 		return 0;
+	};
+
+	// TODO: move to helper functions
+	/** Create a deep copy of data */
+	private cloneDeep = function <T>(o: T): T {
+		return JSON.parse(JSON.stringify(o));
 	};
 
 	/** Export data as CSV

--- a/@angular-generic-table/core/interfaces/gt-options.ts
+++ b/@angular-generic-table/core/interfaces/gt-options.ts
@@ -21,4 +21,6 @@ export interface GtOptions {
 	rowIndex?: string;
 	/** allow table to be unsorted */
 	allowUnsorted?: boolean;
+	/** should data be mutated or deep copy to be made */
+	mutateData?: boolean;
 }


### PR DESCRIPTION
This will make a deep copy of the initial data provided to the table.

option added - mutateData

Closes #263 