### PR TITLE
build(deps): update workspace to Angular 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,96 @@
 # Angular Generic Table
 
-Generic table version 5 has been rebuilt to be more efficient and to make it easier to customize and add new features. It still relies on native html tables for layout and rendering. Follow the instructions below to get started with the latest release candidate.
+A lightweight, configurable table component for Angular. It renders native HTML
+tables and supports sorting, pagination, search with highlighting, row
+selection, keyboard navigation, custom cell/header templates and components, and
+footer calculations.
 
+Built for modern Angular — standalone components, signals, and `OnPush` change
+detection throughout. Compatible with Angular 17 through 22.
 
 ## Install
 
-```
-npm install @angular-generic-table/core@rc --save
+```bash
+npm install @angular-generic-table/core --save
 ```
 
-## Import module
-We recommend import `GenericTableCoreModule` into a shared module eg. `SharedModule` that can be imported into other, preferably lazy loaded modules when needed.
+## Usage
+
+`CoreComponent` is a standalone component (selector: `angular-generic-table`).
+Import it directly into the component where you need it:
+
 ```ts
-import { GenericTableCoreModule } from '@angular-generic-table/core';
+import { Component } from '@angular/core';
+import { CoreComponent, TableConfig } from '@angular-generic-table/core';
 
-@NgModule({
-  declarations: [...],
-  imports: [
-    ...
-    GenericTableCoreModule
-  ],
-  exports: [
-    GenericTableCoreModule
-  ]
+interface Person {
+  firstName: string;
+  lastName: string;
+  favoriteFood: string;
+}
+
+@Component({
+  selector: 'app-people',
+  imports: [CoreComponent],
+  template: `<angular-generic-table [data]="data" [config]="config" />`,
 })
-export class SharedModule {}
+export class PeopleComponent {
+  data: Array<Person> = [
+    { firstName: 'Peter', lastName: 'Parker', favoriteFood: 'Pasta' },
+    { firstName: 'Mary Jane', lastName: 'Watson', favoriteFood: 'Pizza' },
+  ];
+
+  config: TableConfig<Person> = {
+    class: 'table table-striped table-bordered',
+    columns: {
+      firstName: {},
+      lastName: {},
+      favoriteFood: {},
+    },
+  };
+}
 ```
+
+> **Using NgModules?** A backward-compatibility `GenericTableCoreModule` is still
+> exported. Add it to a module's `imports` (e.g. a shared module) to use the
+> table in NgModule-based apps. New apps should prefer importing the standalone
+> `CoreComponent` directly.
 
 ## Import styling
-We recommend setting up your Angular project to use scss (SASS) for css preprocessing.
 
-Once configured to use scss, it's just a matter of including the scss to your main styles file, typically it would be `styles.scss` located at the root of the `src` folder unless you've changed it.
+We recommend setting up your Angular project to use scss (SASS) for css
+preprocessing.
+
+Once configured to use scss, include the library styles in your main styles
+file — typically `styles.scss` at the root of the `src` folder.
 
 ### Add scss
+
 `{project}/src/styles.scss`
 
 ```scss
-// import base styles from angular-generic-table/core
-@use '~@angular-generic-table/core/scss' as generic-table-styles;
+// import base styles from @angular-generic-table/core
+@use '@angular-generic-table/core/scss' as generic-table-styles;
 @include generic-table-styles.styles(); // all styles
 
-// @include generic-table-styles.search-style(); // search (highlight) style
-// @include generic-table-styles.mobile-style(); // mobile layout style
-// @include generic-table-styles.pagination-style(); // pagination styles
+// @include generic-table-styles.search-style();     // search (highlight) style
+// @include generic-table-styles.mobile-style();      // mobile layout style
+// @include generic-table-styles.pagination-style();  // pagination styles
 ```
 
+> **Note:** The webpack-era `~` import prefix is no longer required (or
+> supported) with Angular's current build system — import the package path
+> directly as shown above.
 
 ### Override scss variables
-It's possible to override the scss variables used by generic table by passing them when importing the scss.
+
+It's possible to override the scss variables used by generic table by passing
+them when importing the scss.
 `{project}/src/styles.scss`
 
 ```scss
-// import base styles from angular-generic-table/core and override scss variables
-@use '~@angular-generic-table/core/scss' as generic-table-styles with (
+// import base styles from @angular-generic-table/core and override scss variables
+@use '@angular-generic-table/core/scss' as generic-table-styles with (
     $highlight-background-color: purple,
     $mobile-style-max-width: 375px
 );
@@ -76,8 +114,16 @@ It's possible to override the scss variables used by generic table by passing th
 |$pagination-active-color: | #000; |
 |$pagination-justify-content: | center; |
 
-### Have other needs?
-More examples and use cases coming soon! In the meantime create an [issue over at github](https://github.com/hjalmers/angular-generic-table/issues)
+## Examples
+
+The repo ships a docs app with runnable examples (simple, sorting, pagination,
+custom templates, mobile layout, transpose, footers, and more). Run it locally
+with `ng serve docs`, or browse the source under `projects/docs/src/app/examples`.
+
+## Have other needs?
+
+Found a bug or have a feature request? Create an
+[issue over at github](https://github.com/hjalmers/angular-generic-table/issues).
 
 ## Sponsored by
 

--- a/projects/core/package.json
+++ b/projects/core/package.json
@@ -8,8 +8,8 @@
     "url": "https://github.com/hjalmers/angular-generic-table.git"
   },
   "peerDependencies": {
-    "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
-    "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
+    "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
+    "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0 || ^22.0.0",
     "rxjs": "^7.0.0"
   },
   "dependencies": {

--- a/projects/docs/src/app/pages/intro/intro.component.ts
+++ b/projects/docs/src/app/pages/intro/intro.component.ts
@@ -53,7 +53,7 @@ import { RouterLink } from '@angular/router';
 })
 export class IntroComponent {
   compatibility = [
-    { version: '5.x', angular: '17 – 21' },
+    { version: '5.x', angular: '17 – 22' },
     { version: '5.0.0-rc', angular: '12 – 15' },
     { version: '5.0.0-alpha', angular: '7 – 11' },
     { version: '4.x', angular: '4 – 11' },


### PR DESCRIPTION
## Summary

Upgrades the workspace from Angular 21 to **Angular 22** via the official `ng update` flow, plus the necessary follow-ups and a docs refresh.

### Dependency upgrade
- `ng update @angular/core@22 @angular/cli@22` — all `@angular/*`, `@angular-devkit/build-angular`, `@angular/compiler-cli`, and `ng-packagr` to `22.0.0`.
- **TypeScript 5.9 → 6.0.3** (required by Angular 22).
- `@analogjs/vite-plugin-angular` / `@analogjs/vitest-angular` → `^2.6.0` (older peer range excluded Angular 22).
- Raised `engines` Node floor to `^22.22.3` (Angular CLI 22 minimum).

### Migration follow-ups
- Added `"ignoreDeprecations": "6.0"` to the root tsconfig — TS 6.0 now errors on `baseUrl`/`downlevelIteration`; removing `baseUrl` would have broken the docs app's `paths` resolution.
- Resolved the safe-navigation migration placeholder in `core.component.html` by unwrapping `$safeNavigationMigration(transform?.args)` to `transform.args` (`transform` is guaranteed truthy in those templates, matching the existing `transform.pipe` usage).
- Schematics added `ChangeDetectionStrategy.Eager` to docs example components and `withXhr()` to `provideHttpClient`.

### Library compatibility (`fix(core)`)
- Added `^22.0.0` to the core library's `@angular/common` / `@angular/core` peer dependency ranges so installs on Angular 22 don't emit peer warnings. **This is the `fix(core)` commit that will trigger a patch release on merge.**

### Docs
- Refreshed `README.md`: dropped stale "release candidate"/`@rc` wording, switched the quick-start to standalone `CoreComponent` usage, and removed the webpack-era `~` scss import prefix.
- Added Angular 22 to the version-compatibility table on the intro page.

## Verification
- `npm run build` (core library) ✓
- `npm test` — 171/171 passing ✓
- `npm run build:docs` (production) ✓

## Release impact
The `fix(core):` commit will cause semantic-release to cut a **patch** release (e.g. `5.1.0 → 5.1.1`) when this merges to `main`. The Angular 22 workspace upgrade and docs changes are release-neutral (`build`/`docs`).

https://claude.ai/code/session_01Pki7QYb67QhVAnqeX2fjg4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pki7QYb67QhVAnqeX2fjg4)_